### PR TITLE
serialized visited benches

### DIFF
--- a/Benchwarp/Benches/BenchKeyJsonConverter.cs
+++ b/Benchwarp/Benches/BenchKeyJsonConverter.cs
@@ -1,0 +1,64 @@
+using Newtonsoft.Json;
+
+namespace Benchwarp.Benches;
+
+internal sealed class BenchKeyJsonConverter : JsonConverter<BenchKey>
+{
+    public override void WriteJson(JsonWriter writer, BenchKey value, JsonSerializer serializer)
+    {
+        writer.WriteStartObject();
+        writer.WritePropertyName(nameof(BenchKey.BenchName));
+        writer.WriteValue(value.BenchName);
+        writer.WritePropertyName(nameof(BenchKey.MenuArea));
+        writer.WriteValue(value.MenuArea);
+        writer.WriteEndObject();
+    }
+
+    public override BenchKey ReadJson(JsonReader reader, Type objectType, BenchKey existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null)
+        {
+            return default;
+        }
+
+        string? benchName = null;
+        string? menuArea = null;
+
+        // Current token is StartObject when this converter is invoked.
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonToken.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonToken.PropertyName)
+            {
+                continue;
+            }
+
+            string propertyName = (string)reader.Value!;
+            if (!reader.Read())
+            {
+                continue;
+            }
+
+            switch (propertyName)
+            {
+                case nameof(BenchKey.BenchName):
+                    benchName = reader.Value?.ToString();
+                    break;
+                case nameof(BenchKey.MenuArea):
+                    menuArea = reader.Value?.ToString();
+                    break;
+            }
+        }
+
+        if (benchName is null || menuArea is null)
+        {
+            throw new JsonSerializationException("Bench entries must include both BenchName and MenuArea.");
+        }
+
+        return new BenchKey(benchName, menuArea);
+    }
+}

--- a/Benchwarp/Util/JsonUtil.cs
+++ b/Benchwarp/Util/JsonUtil.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Benchwarp.Benches;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using UnityEngine;
 
@@ -145,5 +146,6 @@ public static class JsonUtil
         _js.Converters.Add(new StringEnumConverter());
         _js.Converters.Add(new Vector2Converter());
         _js.Converters.Add(new Vector3Converter());
+        _js.Converters.Add(new BenchKeyJsonConverter());
     }
 }


### PR DESCRIPTION
Added BenchKeyJsonConverter so each bench key is written/read as a simple { BenchName, MenuArea } object, allowing the visited/locked HashSet<BenchKey> fields to round-trip through JSON files without losing data

Registered the new converter inside JsonUtil, alongside existing enum/vector converters, so every save/load call now uses the bench-aware serialization logic