### PR TITLE
Add door-warp hotkeys, grid navigation, and dropdown hotkey labels

### DIFF
--- a/Benchwarp/Components/BenchDropdown.cs
+++ b/Benchwarp/Components/BenchDropdown.cs
@@ -14,10 +14,8 @@ public class BenchDropdown : MonoBehaviour
     public void Init(GameObject canvas, string name, IReadOnlyList<BenchData> benches)
     {
         dropdownName = name;
-
-        int btnOffsetX = GUIController.btnOffsetX;
-        int btnOffsetY = GUIController.baseDropdownYOffset;
-        int btnHeight = GUIController.btnHeight;
+        int btnOffsetY = GUIController.BaseDropdownYOffset;
+        int btnHeight = GUIController.BtnHeight;
 
         for (int i = 0; i < benches.Count; i++)
         {

--- a/Benchwarp/Components/DropdownRadioSwitch.cs
+++ b/Benchwarp/Components/DropdownRadioSwitch.cs
@@ -5,8 +5,8 @@ namespace Benchwarp.Components;
 
 public class DropdownRadioSwitch : MonoBehaviour
 {
-    private List<(GameObject go, Text text)> buttons = [];
-    private List<string> options = [];
+    private readonly List<(GameObject go, Text text)> buttons = [];
+    private readonly List<string> options = [];
     private bool open = false;
     private int columns = 1;
     private int maxRows = 6;
@@ -21,10 +21,9 @@ public class DropdownRadioSwitch : MonoBehaviour
         this.columns = columns;
         this.maxRows = maxRows;
 
-        int btnOffsetX = GUIController.btnOffsetX;
-        int btnOffsetY = GUIController.baseDropdownYOffset;
-        int btnHeight = GUIController.btnHeight;
-        int btnWidth = GUIController.btnWidth;
+        int btnOffsetY = GUIController.BaseDropdownYOffset;
+        int btnHeight = GUIController.BtnHeight;
+        int btnWidth = GUIController.BtnWidth;
 
         int HorizontalOffset(int column)
         {
@@ -100,7 +99,8 @@ public class DropdownRadioSwitch : MonoBehaviour
             foreach (string str in strs)
             {
                 options.Add(str);
-                buttons[i++].text.text = str;
+                buttons[i].text.text = $"{HotkeyLabel(i)}: {str}";
+                i++;
             }
         }
         catch (Exception e)
@@ -110,6 +110,26 @@ public class DropdownRadioSwitch : MonoBehaviour
         }
         
         if (autoOpen) Show();
+    }
+
+    private string HotkeyLabel(int index)
+    {
+        int column = index % columns;
+        int row = index / columns;
+        char letter = (char)('A' + column);
+        return $"{letter}{row}";
+    }
+
+    public bool TrySelectByGridPosition(int columnIndex, int rowIndex)
+    {
+        if (columnIndex < 0 || columnIndex >= columns) return false;
+        if (rowIndex < 0 || rowIndex >= maxRows) return false;
+        int index = rowIndex * columns + columnIndex;
+        if (index < 0 || index >= options.Count) return false;
+
+        if (!open) Show();
+        Select(index);
+        return true;
     }
 
     public void HideAll()

--- a/Benchwarp/Hotkeys/DoorHotkeyActions.cs
+++ b/Benchwarp/Hotkeys/DoorHotkeyActions.cs
@@ -1,0 +1,70 @@
+using System;
+using Benchwarp.Components;
+using Benchwarp.Settings;
+
+namespace Benchwarp.Hotkeys;
+
+internal static class DoorHotkeyActions
+{
+    public static bool TryHandleDoorGridHotkey(int columnIndex, int rowIndex)
+    {
+        if (!CanHandleDoorHotkeys()) return false;
+
+        DropdownRadioSwitch? dropdown = GetTargetDropdown();
+        return dropdown is not null && dropdown.TrySelectByGridPosition(columnIndex, rowIndex);
+    }
+
+    public static void WarpSelectedDoor() => WithDoorSelector(selector => selector.Warp());
+
+    public static void FlipSelectedDoor() => WithDoorSelector(selector => selector.Flip());
+
+    public static void SelectLastDoor() => WithDoorSelector(selector => selector.LastEntered());
+
+    public static void ToggleAreaDropdown() => ToggleDropdown(gui => gui.DoorAreaSwitch);
+
+    public static void ToggleRoomDropdown() => ToggleDropdown(gui => gui.DoorRoomSwitch);
+
+    public static void ToggleDoorDropdown() => ToggleDropdown(gui => gui.DoorDoorSwitch);
+
+    private static void ToggleDropdown(Func<GUIController, DropdownRadioSwitch> getter)
+    {
+        if (!CanHandleDoorHotkeys()) return;
+        getter(GUIController.Instance).ToggleDropdown();
+    }
+
+    private static void WithDoorSelector(Action<DoorSelectorComponent> action)
+    {
+        if (!CanHandleDoorHotkeys()) return;
+        action(GUIController.Instance.DoorSelector);
+    }
+
+    private static DropdownRadioSwitch? GetTargetDropdown()
+    {
+        GUIController gui = GUIController.Instance;
+        DropdownRadioSwitch door = gui.DoorDoorSwitch;
+        DropdownRadioSwitch room = gui.DoorRoomSwitch;
+        DropdownRadioSwitch area = gui.DoorAreaSwitch;
+
+        if (door.Open) return door;
+        if (room.Open) return room;
+        if (area.Open) return area;
+
+        DoorSelectorComponent selector = gui.DoorSelector;
+        if (selector.Area is null)
+        {
+            area.Show();
+            return area;
+        }
+        if (selector.Room is null)
+        {
+            room.Show();
+            return room;
+        }
+        door.Show();
+        return door;
+    }
+
+    private static bool CanHandleDoorHotkeys()
+        => BenchwarpPlugin.ConfigSettings.MenuMode == MenuMode.DoorWarp
+            && GUIController.Instance.IsDisplaying;
+}

--- a/Benchwarp/Hotkeys/HotkeyActions.cs
+++ b/Benchwarp/Hotkeys/HotkeyActions.cs
@@ -10,14 +10,20 @@ public static class HotkeyActions
     public const string LastBench = "LB";
     public const string StartBench = "SB";
     public const string DoorWarp = "DW";
+    public const string DoorWarpGo = "WD";
+    public const string DoorWarpFlip = "DF";
+    public const string DoorWarpLast = "DL";
+    public const string DoorAreaDropdown = "DA";
+    public const string DoorRoomDropdown = "DR";
+    public const string DoorDoorDropdown = "DD";
     public const string NextPage = "NP";
 
 
     /// <summary>
     /// The current list of letter hotkey codes, accounting for hotkey overrides.
     /// </summary>
-    public static ReadOnlyDictionary<string, Action> CurrentHotkeys { get; } = new(_hotkeys = []);
-    private static readonly Dictionary<string, Action> _hotkeys;
+    public static ReadOnlyDictionary<string, Action> CurrentHotkeys { get; }
+    private static readonly Dictionary<string, Action> _hotkeys = [];
 
     public static ReadOnlyDictionary<string, Action> BaseHotkeys { get; } = new(new Dictionary<string, Action>
     {
@@ -30,12 +36,19 @@ public static class HotkeyActions
             if (BenchwarpPlugin.ConfigSettings.MenuMode != Settings.MenuMode.DoorWarp) BenchwarpPlugin.ConfigSettings.MenuMode = Settings.MenuMode.DoorWarp;
             else BenchwarpPlugin.ConfigSettings.MenuMode = Settings.MenuMode.StandardBenchwarp;
         },
+        [DoorWarpGo] = DoorHotkeyActions.WarpSelectedDoor,
+        [DoorWarpFlip] = DoorHotkeyActions.FlipSelectedDoor,
+        [DoorWarpLast] = DoorHotkeyActions.SelectLastDoor,
+        [DoorAreaDropdown] = DoorHotkeyActions.ToggleAreaDropdown,
+        [DoorRoomDropdown] = DoorHotkeyActions.ToggleRoomDropdown,
+        [DoorDoorDropdown] = DoorHotkeyActions.ToggleDoorDropdown,
         //["DB"], // deploy bench
         [NextPage] = () => GUIController.Instance.NextPage(),
     });
 
     static HotkeyActions()
     {
+        CurrentHotkeys = new(_hotkeys);
         RefreshHotkeys();
     }
 
@@ -64,6 +77,11 @@ public static class HotkeyActions
 
     public static bool TryDoHotkeyAction(int groupIndex, int benchIndex)
     {
+        if (BenchwarpPlugin.ConfigSettings.MenuMode == Settings.MenuMode.DoorWarp && DoorHotkeyActions.TryHandleDoorGridHotkey(groupIndex, benchIndex))
+        {
+            return true;
+        }
+
         if (BenchList.BenchGroups.Count > groupIndex && BenchList.BenchGroups[groupIndex].Benches.Count > benchIndex)
         {
             BenchList.BenchGroups[groupIndex].Benches[benchIndex].MenuSetBench();

--- a/Benchwarp/Settings/SharedSettingsData.cs
+++ b/Benchwarp/Settings/SharedSettingsData.cs
@@ -13,10 +13,21 @@ public class SharedSettingsData
                 [HotkeyActions.LastBench] = HotkeyActions.LastBench,
                 [HotkeyActions.StartBench] = HotkeyActions.StartBench,
                 [HotkeyActions.DoorWarp] = HotkeyActions.DoorWarp,
+                [HotkeyActions.DoorWarpGo] = HotkeyActions.DoorWarpGo,
+                [HotkeyActions.DoorWarpFlip] = HotkeyActions.DoorWarpFlip,
+                [HotkeyActions.DoorWarpLast] = HotkeyActions.DoorWarpLast,
+                [HotkeyActions.DoorAreaDropdown] = HotkeyActions.DoorAreaDropdown,
+                [HotkeyActions.DoorRoomDropdown] = HotkeyActions.DoorRoomDropdown,
+                [HotkeyActions.DoorDoorDropdown] = HotkeyActions.DoorDoorDropdown,
                 [HotkeyActions.NextPage] = HotkeyActions.NextPage,
             }
         };
     }
 
-    public Dictionary<string, string> HotkeyOverrides = [];
+    private Dictionary<string, string> hotkeyOverrides = [];
+    public Dictionary<string, string> HotkeyOverrides
+    {
+        get => hotkeyOverrides;
+        set => hotkeyOverrides = value ?? [];
+    }
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Benchwarp supports hotkeys which can be used in place of menu buttons while the 
 - **LB**: **L**ast **B**ench (equivalent to just clicking Warp).
 - **SB**: **S**tart **B**ench (equivalent to clicking Set Start, then Warp).
 - **DW**: **D**oor **W**arp (equivalent to selecting Door Warp as the menu mode). If used while Door Warp is enabled, switches the mode to Standard Benchwarp.
+- **WD**: Warp to the currently selected door.
+- **DF**: Flip between the linked door pair.
+- **DL**: Select the door you most recently entered.
+- **DA/DR/DD**: Toggle the Area, Room, or Door dropdowns while in Door Warp mode.
 - **NP**: **N**ext **P**age (equivalent to clicking the pages button).
+
+When the Door Warp menu mode is active, letter+number combinations operate the door selector dropdowns instead of bench lists. The letter picks a column (A is the leftmost column on the dropdown grid) and the number picks the row, letting you navigate areas, rooms, and doors without the mouse.
 
 Tip: by default, some letters such as **A** are bound to actions that can cancel the menu. To enter the hotkeys including these letters, you can move the mouse to deselect the Resume button. Alternatively, you can input the hotkey by pressing the buttons nearly simultaneously.
 


### PR DESCRIPTION
- Wire new two-letter door-warp hotkeys (warp/flip/last/toggle dropdowns) and route letter+number input to door dropdown grids while in DoorWarp mode.
- Expose door menu controls and dropdown switches in the GUI controller, convert layout constants to consts, and clean up local vs. static usage.
- Add DoorHotkeyActions helper and extend shared settings defaults to cover the new hotkey codes.
- Display grid codes on dropdown options to show the letter/number mapping; adjust bench dropdown and dropdown radio switch to use the new layout constants.
- Document the new hotkeys and grid behavior in the README.